### PR TITLE
Update strings.po

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -85,7 +85,7 @@ msgid ""%s": Update finished (impossible to update)"
 msgstr ""
 
 msgctxt "#32504"
-msgid ""%s": Update finished (skipped because watched)"
+msgid ""%s": Update skipped (because watched)"
 msgstr ""
 
 msgctxt "#32505"


### PR DESCRIPTION
Changed the message because info about update starting in this case does not appear (was moved to thread function which not run when watched entry)